### PR TITLE
add pseudo-element ::part on inner paper-sliders

### DIFF
--- a/paperwave-range-slider.js
+++ b/paperwave-range-slider.js
@@ -68,7 +68,7 @@ class PaperwaveRangeSlider extends PolymerElement {
         }
 
       </style>
-      <paper-slider id="min-slider" 
+      <paper-slider part="min-slider" id="min-slider" 
           min={{min}}
           max={{max}}
           disabled="{{disabled}}"
@@ -77,7 +77,7 @@ class PaperwaveRangeSlider extends PolymerElement {
           immediate-value={{lowValue}}
           value={{lowValue}}>
       </paper-slider>
-      <paper-slider id="max-slider" 
+      <paper-slider part="max-slider" id="max-slider" 
           min={{min}}
           max={{max}}
           disabled="{{disabled}}"


### PR DESCRIPTION
To allow changing css on inner paper-sliders e.g. to increase width
```js
 paperwave-range-slider::part(min-slider) {
     width : 500px;
}
paperwave-range-slider::part(max-slider) {
      width : 500px;
}
```